### PR TITLE
fix: camera sensitivity config (mouse)

### DIFF
--- a/addons/fp_controller/scripts/player.gd
+++ b/addons/fp_controller/scripts/player.gd
@@ -167,8 +167,8 @@ func _process(_delta: float):
 
 
 func _handle_camera_motion() -> void:
-	rotate_y(mouse_motion.x)
-	camera_pivot.rotate_x(mouse_motion.y)
+	rotate_y(mouse_motion.x * camera_sensitivity)
+	camera_pivot.rotate_x(mouse_motion.y  * camera_sensitivity)
 	
 	camera_pivot.rotation_degrees.x = clampf(
 		camera_pivot.rotation_degrees.x , -89.0, 89.0


### PR DESCRIPTION
Hi Kirill! First of all, thank you for this Godot addon. I'm using in my indie game and it works like a charm.

I'm making the camera sensitivity option in a option panel and I realized that I had to make this small adjustment to make the camera sensitivity work with mouse.

![image](https://github.com/user-attachments/assets/97a8f236-303d-481e-88be-9297e2573fc0)

This code fix this problem and I hope you like it the suggestion.

Thank you.